### PR TITLE
refactor: fix to match segment-type fist and add two lookups to delete duplicate

### DIFF
--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -6,3 +6,4 @@ mod key_bit;
 mod mpt_update;
 mod one_hot;
 mod poseidon;
+mod segment_proof;

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -6,4 +6,5 @@ mod key_bit;
 mod mpt_update;
 mod one_hot;
 mod poseidon;
-mod segment_proof;
+mod proof_segment_path;
+mod segment_proof_direction;

--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -135,6 +135,16 @@ impl MptUpdateConfig {
             key_bit.lookup(),
         );
 
+        cb.add_lookup(
+            "direction is correct for segment and proof types",
+            [
+                segment_type.current(),
+                proof_type.current(),
+                direction.current(),
+            ],
+            segment_proof.lookup(),
+        );
+
         let config = Self {
             selector,
             proof_key,
@@ -166,9 +176,9 @@ impl MptUpdateConfig {
             let conditional_constraints = |cb: &mut ConstraintBuilder<F>| match variant {
                 SegmentType::Start => configure_start(cb, &config),
                 SegmentType::AccountTrie => configure_account_trie(cb, &config),
-                SegmentType::AccountLeaf0 => configure_account_leaf0(cb, &config, segment_proof),
-                SegmentType::AccountLeaf1 => configure_account_leaf1(cb, &config, segment_proof),
-                SegmentType::AccountLeaf2 => configure_account_leaf2(cb, &config, segment_proof),
+                SegmentType::AccountLeaf0 => configure_account_leaf0(cb, &config),
+                SegmentType::AccountLeaf1 => configure_account_leaf1(cb, &config),
+                SegmentType::AccountLeaf2 => configure_account_leaf2(cb, &config),
                 SegmentType::AccountLeaf3 => configure_account_leaf3(cb, &config, rlc, bytes),
                 SegmentType::AccountLeaf4
                 | SegmentType::StorageTrie
@@ -429,11 +439,7 @@ fn configure_account_trie<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &M
     );
 }
 
-fn configure_account_leaf0<F: FieldExt>(
-    cb: &mut ConstraintBuilder<F>,
-    config: &MptUpdateConfig,
-    segment_proof: &impl SegmentProofLookup,
-) {
+fn configure_account_leaf0<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &MptUpdateConfig) {
     cb.assert(
         "from Start or AccountTrie",
         config.selector.current(),
@@ -458,15 +464,6 @@ fn configure_account_leaf0<F: FieldExt>(
         "depth is 0",
         config.selector.current(),
         config.depth.current(),
-    );
-    cb.add_lookup(
-        "direction is correct for segment and proof types",
-        [
-            config.segment_type.current(),
-            config.proof_type.current(),
-            config.direction.current(),
-        ],
-        segment_proof.lookup(),
     );
 
     /* TODO: replaced by above SegmentProofLookup.
@@ -493,11 +490,7 @@ fn configure_account_leaf0<F: FieldExt>(
     // add constraints that sibling = old_path_key and new_path_key
 }
 
-fn configure_account_leaf1<F: FieldExt>(
-    cb: &mut ConstraintBuilder<F>,
-    config: &MptUpdateConfig,
-    segment_proof: &impl SegmentProofLookup,
-) {
+fn configure_account_leaf1<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &MptUpdateConfig) {
     cb.assert(
         "previous is AccountLeaf0",
         config.selector.current(),
@@ -519,15 +512,6 @@ fn configure_account_leaf1<F: FieldExt>(
         "depth is 0",
         config.selector.current(),
         config.depth.current(),
-    );
-    cb.add_lookup(
-        "direction is correct for segment and proof types",
-        [
-            config.segment_type.current(),
-            config.proof_type.current(),
-            config.direction.current(),
-        ],
-        segment_proof.lookup(),
     );
 
     /* TODO: replaced by above SegmentProofLookup.
@@ -559,11 +543,7 @@ fn configure_account_leaf1<F: FieldExt>(
     */
 }
 
-fn configure_account_leaf2<F: FieldExt>(
-    cb: &mut ConstraintBuilder<F>,
-    config: &MptUpdateConfig,
-    segment_proof: &impl SegmentProofLookup,
-) {
+fn configure_account_leaf2<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &MptUpdateConfig) {
     cb.assert(
         "previous is AccountLeaf1",
         config.selector.current(),
@@ -585,15 +565,6 @@ fn configure_account_leaf2<F: FieldExt>(
         "depth is 0",
         config.selector.current(),
         config.depth.current(),
-    );
-    cb.add_lookup(
-        "direction is correct for segment and proof types",
-        [
-            config.segment_type.current(),
-            config.proof_type.current(),
-            config.direction.current(),
-        ],
-        segment_proof.lookup(),
     );
 
     /* TODO: replaced by above SegmentProofLookup.

--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -466,27 +466,6 @@ fn configure_account_leaf0<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &
         config.depth.current(),
     );
 
-    /* TODO: replaced by above SegmentProofLookup.
-
-    for variant in MPTProofType::iter() {
-        let conditional_constraints = |cb: &mut ConstraintBuilder<F>| match variant {
-            MPTProofType::AccountDestructed | MPTProofType::AccountDoesNotExist => todo!(),
-            MPTProofType::BalanceChanged
-            | MPTProofType::CodeHashExists
-            | MPTProofType::CodeSizeExists
-            | MPTProofType::NonceChanged
-            | MPTProofType::PoseidonCodeHashExists
-            | MPTProofType::StorageChanged
-            | MPTProofType::StorageDoesNotExist => cb.add_constraint(
-                "direction is 0",
-                config.selector.current(),
-                config.direction.current(),
-            ),
-        };
-        cb.condition(config.proof_type.matches(variant), conditional_constraints);
-    }
-    */
-
     // add constraints that sibling = old_path_key and new_path_key
 }
 
@@ -513,34 +492,6 @@ fn configure_account_leaf1<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &
         config.selector.current(),
         config.depth.current(),
     );
-
-    /* TODO: replaced by above SegmentProofLookup.
-
-    for variant in MPTProofType::iter() {
-        let conditional_constraints = |cb: &mut ConstraintBuilder<F>| match variant {
-            MPTProofType::AccountDestructed | MPTProofType::AccountDoesNotExist => todo!(),
-            MPTProofType::BalanceChanged
-            | MPTProofType::CodeHashExists
-            | MPTProofType::CodeSizeExists
-            | MPTProofType::NonceChanged
-            | MPTProofType::StorageChanged
-            | MPTProofType::StorageDoesNotExist => cb.add_constraint(
-                "direction is 0",
-                config.selector.current(),
-                config.direction.current(),
-            ),
-            MPTProofType::PoseidonCodeHashExists => {
-                cb.add_constraint(
-                    "direction is 1",
-                    config.selector.current(),
-                    Query::one() - config.direction.current(),
-                );
-                // TODO: add poseidon lookup
-            }
-        };
-        cb.condition(config.proof_type.matches(variant), conditional_constraints);
-    }
-    */
 }
 
 fn configure_account_leaf2<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &MptUpdateConfig) {
@@ -566,31 +517,6 @@ fn configure_account_leaf2<F: FieldExt>(cb: &mut ConstraintBuilder<F>, config: &
         config.selector.current(),
         config.depth.current(),
     );
-
-    /* TODO: replaced by above SegmentProofLookup.
-
-    for variant in MPTProofType::iter() {
-        let conditional_constraints = |cb: &mut ConstraintBuilder<F>| match variant {
-            MPTProofType::AccountDestructed | MPTProofType::AccountDoesNotExist => todo!(),
-            MPTProofType::BalanceChanged
-            | MPTProofType::CodeSizeExists
-            | MPTProofType::NonceChanged => cb.add_constraint(
-                "direction is 0",
-                config.selector.current(),
-                config.direction.current(),
-            ),
-            MPTProofType::CodeHashExists
-            | MPTProofType::StorageChanged
-            | MPTProofType::StorageDoesNotExist => cb.add_constraint(
-                "direction is 1",
-                config.selector.current(),
-                Query::one() - config.direction.current(),
-            ),
-            MPTProofType::PoseidonCodeHashExists => {}
-        };
-        cb.condition(config.proof_type.matches(variant), conditional_constraints);
-    }
-    */
 }
 
 fn configure_account_leaf3<F: FieldExt>(

--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -21,7 +21,7 @@ use strum_macros::EnumIter;
 
 /// Each row of an mpt update belongs to one of four segments.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter)]
-enum SegmentType {
+pub(crate) enum SegmentType {
     Start,
     AccountTrie,
     AccountLeaf0,

--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -21,7 +21,7 @@ use strum_macros::EnumIter;
 
 /// Each row of an mpt update belongs to one of four segments.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter)]
-pub(crate) enum SegmentType {
+pub enum SegmentType {
     Start,
     AccountTrie,
     AccountLeaf0,

--- a/src/gadgets/proof_segment_path.rs
+++ b/src/gadgets/proof_segment_path.rs
@@ -1,0 +1,270 @@
+use super::mpt_update::SegmentType;
+use crate::{
+    constraint_builder::{FixedColumn, Query},
+    MPTProofType,
+};
+use halo2_proofs::{
+    arithmetic::FieldExt, circuit::Region, halo2curves::bn256::Fr, plonk::ConstraintSystem,
+};
+
+/// Segment type path as `previous -> current`.
+struct SegmentPath {
+    previous: SegmentType,
+    current: SegmentType,
+}
+
+impl SegmentPath {
+    const fn new(previous: SegmentType, current: SegmentType) -> Self {
+        Self { previous, current }
+    }
+}
+
+// TODO: need to check and update when implementing the corresponding proof type.
+const PROOF_SEGMENT_PATHS: [(MPTProofType, SegmentPath); 47] = [
+    // Nonce
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::AccountLeaf2),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf2, SegmentType::AccountLeaf3),
+    ),
+    (
+        MPTProofType::NonceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf3, SegmentType::Start),
+    ),
+    // Balance
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::AccountLeaf2),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf2, SegmentType::AccountLeaf3),
+    ),
+    (
+        MPTProofType::BalanceChanged,
+        SegmentPath::new(SegmentType::AccountLeaf3, SegmentType::Start),
+    ),
+    // Keccak code hash
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::AccountLeaf2),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf2, SegmentType::AccountLeaf3),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf3, SegmentType::AccountLeaf4),
+    ),
+    (
+        MPTProofType::CodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf4, SegmentType::Start),
+    ),
+    // poseidon code hash
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::PoseidonCodeHashExists,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::Start),
+    ),
+    // Code size
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::AccountLeaf2),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountLeaf2, SegmentType::AccountLeaf3),
+    ),
+    (
+        MPTProofType::CodeSizeExists,
+        SegmentPath::new(SegmentType::AccountLeaf3, SegmentType::Start),
+    ),
+    // Storage
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountTrie),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::Start, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountTrie, SegmentType::AccountLeaf0),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountLeaf0, SegmentType::AccountLeaf1),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountLeaf1, SegmentType::AccountLeaf2),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountLeaf2, SegmentType::AccountLeaf3),
+    ),
+    (
+        MPTProofType::StorageChanged,
+        SegmentPath::new(SegmentType::AccountLeaf3, SegmentType::Start),
+    ),
+];
+
+pub trait ProofSegmentPathLookup {
+    fn lookup<F: FieldExt>(&self) -> [Query<F>; 3];
+}
+
+#[derive(Clone, Copy)]
+pub struct ProofSegmentPathConfig {
+    proof_type: FixedColumn,
+    previous_segment_type: FixedColumn,
+    current_segment_type: FixedColumn,
+}
+
+impl ProofSegmentPathConfig {
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
+        let [proof_type, previous_segment_type, current_segment_type] =
+            [0; 3].map(|_| FixedColumn(cs.fixed_column()));
+
+        Self {
+            proof_type,
+            previous_segment_type,
+            current_segment_type,
+        }
+    }
+
+    pub fn assign(&self, region: &mut Region<'_, Fr>) {
+        for (offset, (proof_type, segment_path)) in PROOF_SEGMENT_PATHS.iter().enumerate() {
+            for (column, value) in [
+                (self.proof_type, Fr::from(*proof_type as u64)),
+                (
+                    self.previous_segment_type,
+                    Fr::from(segment_path.previous as u64),
+                ),
+                (
+                    self.current_segment_type,
+                    Fr::from(segment_path.current as u64),
+                ),
+            ] {
+                column.assign(region, offset, value);
+            }
+        }
+    }
+}
+
+impl ProofSegmentPathLookup for ProofSegmentPathConfig {
+    fn lookup<F: FieldExt>(&self) -> [Query<F>; 3] {
+        [
+            self.proof_type.current(),
+            self.previous_segment_type.current(),
+            self.current_segment_type.current(),
+        ]
+    }
+}

--- a/src/gadgets/segment_proof.rs
+++ b/src/gadgets/segment_proof.rs
@@ -1,6 +1,6 @@
 use super::mpt_update::SegmentType;
 use crate::{
-    constraint_builder::{AdviceColumn, ConstraintBuilder, Query},
+    constraint_builder::{FixedColumn, Query},
     MPTProofType,
 };
 use halo2_proofs::{
@@ -59,17 +59,15 @@ pub trait SegmentProofLookup {
 
 #[derive(Clone, Copy)]
 pub struct SegmentProofConfig {
-    segment_type: AdviceColumn,
-    proof_type: AdviceColumn,
-    direction: AdviceColumn,
+    segment_type: FixedColumn,
+    proof_type: FixedColumn,
+    direction: FixedColumn,
 }
 
 impl SegmentProofConfig {
-    pub fn configure<F: FieldExt>(
-        cs: &mut ConstraintSystem<F>,
-        cb: &mut ConstraintBuilder<F>,
-    ) -> Self {
-        let [segment_type, proof_type, direction] = cb.advice_columns(cs);
+    pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
+        let [segment_type, proof_type, direction] = [0; 3].map(|_| FixedColumn(cs.fixed_column()));
+
         Self {
             segment_type,
             proof_type,

--- a/src/gadgets/segment_proof.rs
+++ b/src/gadgets/segment_proof.rs
@@ -7,7 +7,8 @@ use halo2_proofs::{
     arithmetic::FieldExt, circuit::Region, halo2curves::bn256::Fr, plonk::ConstraintSystem,
 };
 
-const SEGMENT_PROOF_DIRECTION_TUPLES: [(SegmentType, MPTProofType, u64); 20] = [
+// TODO: need to check and update when implementing the corresponding proof type.
+const SEGMENT_PROOF_DIRECTION_TUPLES: [(SegmentType, MPTProofType, u64); 27] = [
     // AccountLeaf0
     (SegmentType::AccountLeaf0, MPTProofType::BalanceChanged, 0),
     (SegmentType::AccountLeaf0, MPTProofType::CodeHashExists, 0),
@@ -51,6 +52,15 @@ const SEGMENT_PROOF_DIRECTION_TUPLES: [(SegmentType, MPTProofType, u64); 20] = [
         MPTProofType::StorageDoesNotExist,
         1,
     ),
+    // AccountLeaf3
+    (SegmentType::AccountLeaf3, MPTProofType::BalanceChanged, 1),
+    (SegmentType::AccountLeaf3, MPTProofType::CodeSizeExists, 0),
+    (SegmentType::AccountLeaf3, MPTProofType::NonceChanged, 0),
+    (SegmentType::AccountLeaf3, MPTProofType::CodeHashExists, 1),
+    (SegmentType::AccountLeaf3, MPTProofType::StorageChanged, 0),
+    // AccountLeaf4
+    (SegmentType::AccountLeaf4, MPTProofType::CodeHashExists, 0),
+    (SegmentType::AccountLeaf4, MPTProofType::CodeHashExists, 1),
 ];
 
 pub trait SegmentProofLookup {

--- a/src/gadgets/segment_proof.rs
+++ b/src/gadgets/segment_proof.rs
@@ -1,0 +1,51 @@
+use crate::constraint_builder::{AdviceColumn, ConstraintBuilder, Query};
+use halo2_proofs::{
+    arithmetic::FieldExt, circuit::Region, halo2curves::bn256::Fr, plonk::ConstraintSystem,
+};
+
+pub trait SegmentProofLookup {
+    fn lookup<F: FieldExt>(&self) -> [Query<F>; 3];
+}
+
+#[derive(Clone, Copy)]
+pub struct SegmentProofConfig {
+    segment_type: AdviceColumn,
+    proof_type: AdviceColumn,
+    direction: AdviceColumn,
+}
+
+impl SegmentProofConfig {
+    pub fn configure<F: FieldExt>(
+        cs: &mut ConstraintSystem<F>,
+        cb: &mut ConstraintBuilder<F>,
+    ) -> Self {
+        let [segment_type, proof_type, direction] = cb.advice_columns(cs);
+        Self {
+            segment_type,
+            proof_type,
+            direction,
+        }
+    }
+
+    pub fn assign(&self, region: &mut Region<'_, Fr>, traces: &[(Fr, Fr, Fr)]) {
+        for (offset, trace) in traces.iter().enumerate() {
+            for (column, value) in [
+                (self.segment_type, trace.0),
+                (self.proof_type, trace.1),
+                (self.direction, trace.2),
+            ] {
+                column.assign(region, offset, value);
+            }
+        }
+    }
+}
+
+impl SegmentProofLookup for SegmentProofConfig {
+    fn lookup<F: FieldExt>(&self) -> [Query<F>; 3] {
+        [
+            self.segment_type.current(),
+            self.proof_type.current(),
+            self.direction.current(),
+        ]
+    }
+}

--- a/src/gadgets/segment_proof_direction.rs
+++ b/src/gadgets/segment_proof_direction.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
 };
 
 // TODO: need to check and update when implementing the corresponding proof type.
-const SEGMENT_PROOF_DIRECTION_TUPLES: [(SegmentType, MPTProofType, u64); 27] = [
+const SEGMENT_PROOF_DIRECTIONS: [(SegmentType, MPTProofType, u64); 27] = [
     // AccountLeaf0
     (SegmentType::AccountLeaf0, MPTProofType::BalanceChanged, 0),
     (SegmentType::AccountLeaf0, MPTProofType::CodeHashExists, 0),
@@ -63,18 +63,18 @@ const SEGMENT_PROOF_DIRECTION_TUPLES: [(SegmentType, MPTProofType, u64); 27] = [
     (SegmentType::AccountLeaf4, MPTProofType::CodeHashExists, 1),
 ];
 
-pub trait SegmentProofLookup {
+pub trait SegmentProofDirectionLookup {
     fn lookup<F: FieldExt>(&self) -> [Query<F>; 3];
 }
 
 #[derive(Clone, Copy)]
-pub struct SegmentProofConfig {
+pub struct SegmentProofDirectionConfig {
     segment_type: FixedColumn,
     proof_type: FixedColumn,
     direction: FixedColumn,
 }
 
-impl SegmentProofConfig {
+impl SegmentProofDirectionConfig {
     pub fn configure<F: FieldExt>(cs: &mut ConstraintSystem<F>) -> Self {
         let [segment_type, proof_type, direction] = [0; 3].map(|_| FixedColumn(cs.fixed_column()));
 
@@ -86,7 +86,7 @@ impl SegmentProofConfig {
     }
 
     pub fn assign(&self, region: &mut Region<'_, Fr>) {
-        for (offset, tuple) in SEGMENT_PROOF_DIRECTION_TUPLES.iter().enumerate() {
+        for (offset, tuple) in SEGMENT_PROOF_DIRECTIONS.iter().enumerate() {
             for (column, value) in [
                 (self.segment_type, Fr::from(tuple.0 as u64)),
                 (self.proof_type, Fr::from(tuple.1 as u64)),
@@ -98,7 +98,7 @@ impl SegmentProofConfig {
     }
 }
 
-impl SegmentProofLookup for SegmentProofConfig {
+impl SegmentProofDirectionLookup for SegmentProofDirectionConfig {
     fn lookup<F: FieldExt>(&self) -> [Query<F>; 3] {
         [
             self.segment_type.current(),


### PR DESCRIPTION
Try to fix this comment https://github.com/scroll-tech/mpt-circuit/pull/28#pullrequestreview-1385117785.

Also  close https://github.com/scroll-tech/mpt-circuit/issues/35

### Summary

1. Update to match segment-type first (then proof-type) to avoid duplicate constraints.

2. Add `SegmentProofDirectionLookup` to lookup `(segement_type, proof_type, direction)` (and delete duplicate constraints).

3. Add `ProofSegmentPathLookup` to lookup `(proof_type, previous_segment_type, current_segment_type)`.