### PR TITLE
Add lookup_exprs to mpt circuit

### DIFF
--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -39,7 +39,7 @@ lazy_static! {
 }
 
 pub trait MptUpdateLookup<F: FieldExt> {
-    fn lookup(&self) -> [Query<F>; 7];
+    fn lookup(&self) -> [Query<F>; 8];
 }
 
 #[derive(Clone)]
@@ -68,7 +68,7 @@ pub struct MptUpdateConfig {
 }
 
 impl<F: FieldExt> MptUpdateLookup<F> for MptUpdateConfig {
-    fn lookup(&self) -> [Query<F>; 7] {
+    fn lookup(&self) -> [Query<F>; 8] {
         let is_start = || self.segment_type.current_matches(&[SegmentType::Start]);
         let old_root = self.old_hash.current() * is_start();
         let new_root = self.new_hash.current() * is_start();
@@ -78,13 +78,14 @@ impl<F: FieldExt> MptUpdateLookup<F> for MptUpdateConfig {
         let address = self.intermediate_values[0].current() * is_start();
         let storage_key_rlc = self.storage_key_rlc.current() * is_start();
         [
-            proof_type,
-            old_root,
-            new_root,
-            old_value,
-            new_value,
+            is_start().into(),
             address,
             storage_key_rlc,
+            proof_type,
+            new_root,
+            old_root,
+            new_value,
+            old_value,
         ]
     }
 }

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -5,16 +5,20 @@ use crate::{
         byte_representation::ByteRepresentationConfig,
         canonical_representation::CanonicalRepresentationConfig,
         key_bit::KeyBitConfig,
-        mpt_update::{byte_representations, key_bit_lookups, mpt_update_keys, MptUpdateConfig},
+        mpt_update::{
+            byte_representations, key_bit_lookups, mpt_update_keys, MptUpdateConfig,
+            MptUpdateLookup,
+        },
         poseidon::PoseidonLookup,
         rlc_randomness::RlcRandomness,
     },
     types::Proof,
 };
 use halo2_proofs::{
+    arithmetic::FieldExt,
     circuit::Layouter,
     halo2curves::bn256::Fr,
-    plonk::{Challenge, ConstraintSystem, Error},
+    plonk::{Challenge, ConstraintSystem, Error, Expression, VirtualCells},
 };
 
 /// Config for MptCircuit
@@ -113,6 +117,10 @@ impl MptCircuitConfig {
                 Ok(())
             },
         )
+    }
+
+    pub fn lookup_exprs<F: FieldExt>(&self, meta: &mut VirtualCells<'_, F>) -> [Expression<F>; 8] {
+        self.mpt_update.lookup().map(|q| q.run(meta))
     }
 }
 


### PR DESCRIPTION
This allows the mpt table in the super circuit to lookup into the mpt circuit.