### PR TITLE
Re-enable balance range checks

### DIFF
--- a/src/constraint_builder.rs
+++ b/src/constraint_builder.rs
@@ -31,7 +31,10 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     }
 
     pub fn every_row_selector(&self) -> BinaryQuery<F> {
-        self.conditions.first().expect("every_row selector should always be first condition").clone()
+        self.conditions
+            .first()
+            .expect("every_row selector should always be first condition")
+            .clone()
     }
 
     pub fn assert_zero(&mut self, name: &'static str, query: Query<F>) {
@@ -68,7 +71,8 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     ) {
         let condition = self
             .conditions
-            .iter().skip(1) // Save a degree by skipping every row selector
+            .iter()
+            .skip(1) // Save a degree by skipping every row selector
             .fold(BinaryQuery::one(), |a, b| a.clone().and(b.clone()));
         let lookup = left
             .into_iter()
@@ -87,7 +91,8 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     ) {
         let condition = self
             .conditions
-            .iter().skip(1) // Save a degree by skipping every row selector
+            .iter()
+            .skip(1) // Save a degree by skipping every row selector
             .fold(BinaryQuery::one(), |a, b| a.clone().and(b.clone()));
         let lookup = left
             .into_iter()

--- a/src/gadgets/byte_representation.rs
+++ b/src/gadgets/byte_representation.rs
@@ -144,7 +144,10 @@ fn fr_to_big_endian(x: &Fr) -> Vec<u8> {
     let mut bytes = x.to_bytes();
     bytes.reverse();
     // We only the 31 least significant bytes of x so that the value column will not overflow.
-    // assert_eq!(bytes[0], 0);
+    assert_eq!(bytes[0], 0);
+    if bytes[0] != 0 {
+        log::error!("Fr {:?} does not fit into 31 bytes", x);
+    }
     bytes[1..].to_vec()
 }
 

--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -1366,7 +1366,7 @@ fn configure_code_size<F: FieldExt>(
 fn configure_balance<F: FieldExt>(
     cb: &mut ConstraintBuilder<F>,
     config: &MptUpdateConfig,
-    _rlc: &impl RlcLookup,
+    rlc: &impl RlcLookup,
 ) {
     for variant in SegmentType::iter() {
         let conditional_constraints = |cb: &mut ConstraintBuilder<F>| match variant {
@@ -1404,32 +1404,32 @@ fn configure_balance<F: FieldExt>(
                     config
                         .path_type
                         .current_matches(&[PathType::Common, PathType::ExtensionOld]),
-                    |_cb| {
-                        // cb.add_lookup(
-                        //     "old balance is rlc(old_hash) and fits into 31 bytes",
-                        //     [
-                        //         config.old_hash.current(),
-                        //         Query::from(30),
-                        //         config.old_value.current(),
-                        //     ],
-                        //     rlc.lookup(),
-                        // );
+                    |cb| {
+                        cb.add_lookup(
+                            "old balance is rlc(old_hash) and fits into 31 bytes",
+                            [
+                                config.old_hash.current(),
+                                Query::from(30),
+                                config.old_value.current(),
+                            ],
+                            rlc.lookup(),
+                        );
                     },
                 );
                 cb.condition(
                     config
                         .path_type
                         .current_matches(&[PathType::Common, PathType::ExtensionNew]),
-                    |_cb| {
-                        // cb.add_lookup(
-                        //     "new balance is rlc(new_hash) and fits into 31 bytes",
-                        //     [
-                        //         config.new_hash.current(),
-                        //         Query::from(30),
-                        //         config.new_value.current(),
-                        //     ],
-                        //     rlc.lookup(),
-                        // );
+                    |cb| {
+                        cb.add_lookup(
+                            "new balance is rlc(new_hash) and fits into 31 bytes",
+                            [
+                                config.new_hash.current(),
+                                Query::from(30),
+                                config.new_value.current(),
+                            ],
+                            rlc.lookup(),
+                        );
                     },
                 );
             }


### PR DESCRIPTION
This is ok to merge once https://github.com/scroll-tech/test-traces/pull/10 reduces the balances below 31 bytes.