### PR TITLE
RLC old and new roots for MPT update

### DIFF
--- a/src/constraint_builder.rs
+++ b/src/constraint_builder.rs
@@ -31,7 +31,10 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     }
 
     pub fn every_row_selector(&self) -> BinaryQuery<F> {
-        self.conditions.first().expect("every_row selector should always be first condition").clone()
+        self.conditions
+            .first()
+            .expect("every_row selector should always be first condition")
+            .clone()
     }
 
     pub fn assert_zero(&mut self, name: &'static str, query: Query<F>) {
@@ -68,7 +71,8 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     ) {
         let condition = self
             .conditions
-            .iter().skip(1) // Save a degree by skipping every row selector
+            .iter()
+            .skip(1) // Save a degree by skipping every row selector
             .fold(BinaryQuery::one(), |a, b| a.clone().and(b.clone()));
         let lookup = left
             .into_iter()
@@ -87,7 +91,8 @@ impl<F: FieldExt> ConstraintBuilder<F> {
     ) {
         let condition = self
             .conditions
-            .iter().skip(1) // Save a degree by skipping every row selector
+            .iter()
+            .skip(1) // Save a degree by skipping every row selector
             .fold(BinaryQuery::one(), |a, b| a.clone().and(b.clone()));
         let lookup = left
             .into_iter()

--- a/src/gadgets/canonical_representation.rs
+++ b/src/gadgets/canonical_representation.rs
@@ -1,11 +1,15 @@
 use super::super::constraint_builder::{
-    AdviceColumn, BinaryColumn, ConstraintBuilder, FixedColumn, Query, SelectorColumn,
+    AdviceColumn, BinaryColumn, ConstraintBuilder, FixedColumn, Query, SecondPhaseAdviceColumn,
+    SelectorColumn,
 };
-use super::{byte_bit::RangeCheck256Lookup, is_zero::IsZeroGadget};
+use super::{
+    byte_bit::RangeCheck256Lookup, byte_representation::RlcLookup, is_zero::IsZeroGadget,
+    rlc_randomness::RlcRandomness,
+};
 use ethers_core::types::U256;
 use halo2_proofs::{
     arithmetic::{Field, FieldExt},
-    circuit::Region,
+    circuit::{Region, Value},
     halo2curves::bn256::Fr,
     plonk::ConstraintSystem,
 };
@@ -22,11 +26,13 @@ pub struct CanonicalRepresentationConfig {
     value: AdviceColumn, // We're proving value.to_le_bytes()[i] = byte in this gadget
     index: FixedColumn,  // (0..32).repeat()
     byte: AdviceColumn,  // we need to prove that bytes form the canonical representation of value.
+    rlc: SecondPhaseAdviceColumn, // Accumulated random linear combination of canonical representation bytes.
 
     // Witness columns
     index_is_zero: SelectorColumn, // (0..32).repeat().map(|i| i == 0)
-    modulus_byte: FixedColumn,     // (0..32).repeat().map(|i| Fr::MODULUS.to_be_bytes()[i])
-    difference: AdviceColumn,      // modulus_byte - byte
+    // index_is_31: SelectorColumn, // (0..32).repeat().map(|i| i == 31)
+    modulus_byte: FixedColumn, // (0..32).repeat().map(|i| Fr::MODULUS.to_be_bytes()[i])
+    difference: AdviceColumn,  // modulus_byte - byte
     difference_is_zero: IsZeroGadget,
     differences_are_zero_so_far: BinaryColumn, // difference[0] ... difference[index - 1] are all 0.
 }
@@ -36,9 +42,11 @@ impl CanonicalRepresentationConfig {
         cs: &mut ConstraintSystem<Fr>,
         cb: &mut ConstraintBuilder<Fr>,
         range_check: &impl RangeCheck256Lookup,
+        randomness: &RlcRandomness,
     ) -> Self {
         let ([index_is_zero], [index, modulus_byte], [value, byte, difference]) =
             cb.build_columns(cs);
+        let [rlc] = cb.second_phase_advice_columns(cs);
 
         let [differences_are_zero_so_far] = cb.binary_columns(cs);
         let difference_is_zero = IsZeroGadget::configure(cs, cb, difference);
@@ -61,6 +69,7 @@ impl CanonicalRepresentationConfig {
                 "differences_are_zero_so_far = 1 when index = 0",
                 differences_are_zero_so_far.current(),
             );
+            cb.assert_equal("???????", rlc.current(), byte.current());
         });
         cb.condition(!index_is_zero.current(), |cb| {
             cb.assert_equal(
@@ -75,6 +84,11 @@ impl CanonicalRepresentationConfig {
                     .previous()
                     .and(difference_is_zero.previous())
                     .into(),
+            );
+            cb.assert_equal(
+                "???",
+                rlc.current() ,
+                rlc.previous() * randomness.query() + byte.current(),
             );
         });
 
@@ -104,6 +118,7 @@ impl CanonicalRepresentationConfig {
             value,
             index,
             byte,
+            rlc,
             index_is_zero,
             modulus_byte,
             difference,
@@ -112,7 +127,7 @@ impl CanonicalRepresentationConfig {
         }
     }
 
-    pub fn assign(&self, region: &mut Region<'_, Fr>, values: &[Fr]) {
+    pub fn assign(&self, region: &mut Region<'_, Fr>, randomness: Value<Fr>, values: &[Fr]) {
         let modulus = U256::from_str_radix(Fr::MODULUS, 16).unwrap();
         let mut modulus_bytes = [0u8; 32];
         modulus.to_big_endian(&mut modulus_bytes);
@@ -123,6 +138,7 @@ impl CanonicalRepresentationConfig {
             let mut bytes = value.to_bytes();
             bytes.reverse();
             let mut differences_are_zero_so_far = true;
+            let mut rlc = Value::known(Fr::zero());
             for (index, (byte, modulus_byte)) in bytes.iter().zip_eq(&modulus_bytes).enumerate() {
                 self.byte.assign(region, offset, u64::from(*byte));
                 self.modulus_byte
@@ -147,6 +163,9 @@ impl CanonicalRepresentationConfig {
 
                 self.value.assign(region, offset, *value);
 
+                rlc = rlc * randomness + Value::known(Fr::from(u64::from(*byte)));
+                self.rlc.assign(region, offset, rlc);
+
                 offset += 1
             }
         }
@@ -159,6 +178,16 @@ impl CanonicalRepresentationLookup for CanonicalRepresentationConfig {
             self.value.current(),
             self.index.current(),
             self.byte.current(),
+        ]
+    }
+}
+
+impl RlcLookup for CanonicalRepresentationConfig {
+    fn lookup<F: FieldExt>(&self) -> [Query<F>; 3] {
+        [
+            self.value.current(),
+            self.rlc.current(),
+            self.index.current(),
         ]
     }
 }
@@ -178,7 +207,12 @@ mod test {
     }
 
     impl Circuit<Fr> for TestCircuit {
-        type Config = (SelectorColumn, ByteBitGadget, CanonicalRepresentationConfig);
+        type Config = (
+            SelectorColumn,
+            ByteBitGadget,
+            RlcRandomness,
+            CanonicalRepresentationConfig,
+        );
         type FloorPlanner = SimpleFloorPlanner;
 
         fn without_witnesses(&self) -> Self {
@@ -190,10 +224,11 @@ mod test {
             let mut cb = ConstraintBuilder::new(selector);
 
             let byte_bit = ByteBitGadget::configure(cs, &mut cb);
+            let randomness = RlcRandomness::configure(cs);
             let canonical_representation =
-                CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit);
+                CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit, &randomness);
             cb.build(cs);
-            (selector, byte_bit, canonical_representation)
+            (selector, byte_bit, randomness, canonical_representation)
         }
 
         fn synthesize(
@@ -201,7 +236,8 @@ mod test {
             config: Self::Config,
             mut layouter: impl Layouter<Fr>,
         ) -> Result<(), Error> {
-            let (selector, byte_bit, canonical_representation) = config;
+            let (selector, byte_bit, rlc_randomness, canonical_representation) = config;
+            let randomness = rlc_randomness.value(&layouter);
             layouter.assign_region(
                 || "",
                 |mut region| {
@@ -209,7 +245,7 @@ mod test {
                         selector.enable(&mut region, offset);
                     }
                     byte_bit.assign(&mut region);
-                    canonical_representation.assign(&mut region, &self.values);
+                    canonical_representation.assign(&mut region, randomness, &self.values);
                     Ok(())
                 },
             )
@@ -223,5 +259,17 @@ mod test {
         };
         let prover = MockProver::<Fr>::run(14, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()));
+    }
+
+    #[test]
+    fn test_byte_ordering() {
+        let value = Fr::from(258);
+        let mut bytes = value.to_bytes();
+        bytes.reverse();
+
+        let mut expected = [0; 32];
+        expected[30] = 1;
+        expected[31] = 2;
+        assert_eq!(bytes, expected);
     }
 }

--- a/src/gadgets/key_bit.rs
+++ b/src/gadgets/key_bit.rs
@@ -1,6 +1,7 @@
 use super::{
     byte_bit::{ByteBitLookup, RangeCheck256Lookup, RangeCheck8Lookup},
     canonical_representation::CanonicalRepresentationLookup,
+    rlc_randomness::RlcRandomness,
 };
 use crate::constraint_builder::{AdviceColumn, ConstraintBuilder, Query, SelectorColumn};
 use halo2_proofs::{
@@ -143,6 +144,7 @@ mod test {
             KeyBitConfig,
             ByteBitGadget,
             CanonicalRepresentationConfig,
+            RlcRandomness,
         );
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -155,8 +157,9 @@ mod test {
             let mut cb = ConstraintBuilder::new(selector);
 
             let byte_bit = ByteBitGadget::configure(cs, &mut cb);
+            let randomness = RlcRandomness::configure(cs);
             let canonical_representation =
-                CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit);
+                CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit, &randomness);
             let key_bit = KeyBitConfig::configure(
                 cs,
                 &mut cb,
@@ -166,7 +169,13 @@ mod test {
                 &byte_bit,
             );
             cb.build(cs);
-            (selector, key_bit, byte_bit, canonical_representation)
+            (
+                selector,
+                key_bit,
+                byte_bit,
+                canonical_representation,
+                randomness,
+            )
         }
 
         fn synthesize(
@@ -176,7 +185,8 @@ mod test {
         ) -> Result<(), Error> {
             let keys: Vec<_> = self.lookups.iter().map(|lookup| lookup.0).collect();
 
-            let (selector, key_bit, byte_bit, canonical_representation) = config;
+            let (selector, key_bit, byte_bit, canonical_representation, rlc_randomness) = config;
+            let randomness = rlc_randomness.value(&layouter);
 
             layouter.assign_region(
                 || "",
@@ -187,7 +197,7 @@ mod test {
 
                     key_bit.assign(&mut region, &self.lookups);
                     byte_bit.assign(&mut region);
-                    canonical_representation.assign(&mut region, &keys);
+                    canonical_representation.assign(&mut region, randomness, &keys);
                     Ok(())
                 },
             )

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -47,7 +47,7 @@ impl MptCircuitConfig {
         let byte_representation =
             ByteRepresentationConfig::configure(cs, &mut cb, &byte_bit, &rlc_randomness);
         let canonical_representation =
-            CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit);
+            CanonicalRepresentationConfig::configure(cs, &mut cb, &byte_bit, &rlc_randomness);
         let key_bit = KeyBitConfig::configure(
             cs,
             &mut cb,
@@ -65,6 +65,7 @@ impl MptCircuitConfig {
             &byte_representation,
             &byte_representation,
             &rlc_randomness,
+            &canonical_representation,
         );
 
         cb.build(cs);
@@ -96,8 +97,11 @@ impl MptCircuitConfig {
                     self.selector.enable(&mut region, offset);
                 }
 
-                self.canonical_representation
-                    .assign(&mut region, &mpt_update_keys(proofs));
+                self.canonical_representation.assign(
+                    &mut region,
+                    randomness,
+                    &mpt_update_keys(proofs),
+                );
                 self.key_bit.assign(&mut region, &key_bit_lookups(proofs));
                 self.byte_bit.assign(&mut region);
                 self.byte_representation


### PR DESCRIPTION
Doing this minimizes the changes we need make from the upstream PSE zkevm circuit. In that one, the state roots are U256's so they need to be RLC'ed to fit into a field element.