### PR TITLE
[FIX] poseidon lookup do not need "default" lookup

### DIFF
--- a/src/gadgets/poseidon.rs
+++ b/src/gadgets/poseidon.rs
@@ -41,7 +41,7 @@ impl<F: FieldExt> ConstraintBuilder<F> {
 
         let (q_enable, [hash, left, right, control, head_mark]) = poseidon.lookup_columns();
 
-        self.add_lookup_with_default(
+        self.add_lookup(
             name,
             extended_queries,
             [
@@ -51,14 +51,6 @@ impl<F: FieldExt> ConstraintBuilder<F> {
                 right.current(),
                 control.current(),
                 head_mark.current(),
-            ],
-            [
-                Query::one(),
-                Query::from(*HASH_ZERO_ZERO),
-                Query::zero(),
-                Query::zero(),
-                Query::zero(),
-                Query::one(),
             ],
         )
     }


### PR DESCRIPTION
Poseidon table include one fixed column and 5 advice columns. There is always a row that all coloums (inclue the fixed one) is 0. So in `poseidon_lookup` if the condition is false we would always lookup into this row.
