### PR TITLE
Assign all 0 row in mpt circuit for all 0 row in mpt table

### DIFF
--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -72,7 +72,7 @@ impl<F: FieldExt> MptUpdateLookup<F> for MptUpdateConfig {
         let is_start = || self.segment_type.current_matches(&[SegmentType::Start]);
         let old_root_rlc = self.second_phase_intermediate_values[0].current() * is_start();
         let new_root_rlc = self.second_phase_intermediate_values[1].current() * is_start();
-        let proof_type = self.proof_type.current();
+        let proof_type = self.proof_type.current() * is_start();
         let old_value = self.old_value.current() * is_start();
         let new_value = self.new_value.current() * is_start();
         let address = self.intermediate_values[0].current() * is_start();
@@ -325,7 +325,7 @@ impl MptUpdateConfig {
         randomness: Value<Fr>,
     ) -> usize {
         let mut n_rows = 0;
-        let mut offset = 0;
+        let mut offset = 1; // selector on first row is disabled.
         for proof in proofs {
             let proof_type = MPTProofType::from(proof.claim);
             let storage_key =
@@ -485,7 +485,7 @@ impl MptUpdateConfig {
                 self.intermediate_values[3].assign(region, offset, other_leaf_data_hash);
 
                 n_rows += proof.n_rows();
-                offset = n_rows;
+                offset = 1 + n_rows;
                 continue; // we don't need to assign any leaf rows for empty accounts
             }
 
@@ -615,7 +615,7 @@ impl MptUpdateConfig {
             }
             self.assign_storage(region, next_offset, &proof.storage, randomness);
             n_rows += proof.n_rows();
-            offset = n_rows;
+            offset = 1 + n_rows;
         }
         n_rows
     }
@@ -1749,7 +1749,7 @@ fn configure_empty_storage<F: FieldExt>(
                 poseidon,
             );
             cb.poseidon_lookup(
-                "old_hash == new_hash = h(key_hash, other_leaf_data_hash)",
+                "old_hash = new_hash = h(key_hash, other_leaf_data_hash)",
                 [
                     other_key_hash.current(),
                     other_leaf_data_hash.current(),
@@ -1848,7 +1848,7 @@ fn configure_empty_account<F: FieldExt>(
                             poseidon,
                         );
                         cb.poseidon_lookup(
-                            "old_hash == new_hash = h(key_hash, other_leaf_data_hash)",
+                            "old_hash = new_hash = h(key_hash, other_leaf_data_hash)",
                             [
                                 other_key_hash.current(),
                                 other_leaf_data_hash.current(),

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -18,7 +18,6 @@ use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::Layouter,
     halo2curves::bn256::Fr,
-    poly::Rotation,
     plonk::{Challenge, ConstraintSystem, Error, Expression, VirtualCells},
 };
 

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -18,6 +18,7 @@ use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::Layouter,
     halo2curves::bn256::Fr,
+    poly::Rotation,
     plonk::{Challenge, ConstraintSystem, Error, Expression, VirtualCells},
 };
 
@@ -93,7 +94,7 @@ impl MptCircuitConfig {
         layouter.assign_region(
             || "mpt circuit",
             |mut region| {
-                for offset in 0..n_rows {
+                for offset in 1..n_rows {
                     self.selector.enable(&mut region, offset);
                 }
 
@@ -127,7 +128,7 @@ impl MptCircuitConfig {
                     "mpt circuit requires {n_assigned_rows} rows > limit of {n_rows} rows"
                 );
 
-                for offset in n_assigned_rows..n_rows {
+                for offset in 1 + n_assigned_rows..n_rows {
                     self.mpt_update.assign_padding_row(&mut region, offset);
                 }
 

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -101,7 +101,9 @@ impl MptCircuitConfig {
                 // pad canonical_representation to fixed count
                 // notice each input cost 32 rows in canonical_representation, and inside
                 // assign one extra input is added
-                let keys = mpt_update_keys(proofs);
+                let mut keys = mpt_update_keys(proofs);
+                keys.sort();
+                keys.dedup();
                 let total_rep_size = n_rows / 32 - 1;
                 assert!(
                     total_rep_size >= keys.len(),


### PR DESCRIPTION
This all zero row in the mpt table is needed for disabled mpt update lookups.

Also deduplicate keys for the canonical representation lookup.

