### PR TITLE
fix-build: add derive `Ord` to `OneHot`

### DIFF
--- a/src/gadgets/mpt_update/path.rs
+++ b/src/gadgets/mpt_update/path.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use strum_macros::EnumIter;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, EnumIter, Hash)]
 pub enum PathType {
     Start,        // Used as boundary marker between updates
     Common,       // Hashes for both the old and new path are being updated.

--- a/src/gadgets/mpt_update/segment.rs
+++ b/src/gadgets/mpt_update/segment.rs
@@ -2,7 +2,7 @@ use crate::MPTProofType;
 use std::collections::HashMap;
 use strum_macros::EnumIter;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, EnumIter, Hash)]
 pub enum SegmentType {
     Start, // Boundary marker between updates
     AccountTrie,

--- a/src/gadgets/one_hot.rs
+++ b/src/gadgets/one_hot.rs
@@ -7,11 +7,11 @@ use strum::IntoEnumIterator;
 // It's useful to have 1 less column so that the default assigment for the gadget
 // is valid (it will represent the first variant).
 #[derive(Clone)]
-pub struct OneHot<T: Hash> {
+pub struct OneHot<T: Hash + PartialOrd + Ord> {
     columns: BTreeMap<T, BinaryColumn>,
 }
 
-impl<T: IntoEnumIterator + Hash + Eq> OneHot<T> {
+impl<T: IntoEnumIterator + Hash + Eq + PartialOrd + Ord> OneHot<T> {
     pub fn configure<F: FieldExt>(
         cs: &mut ConstraintSystem<F>,
         cb: &mut ConstraintBuilder<F>,

--- a/src/mpt_table.rs
+++ b/src/mpt_table.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 /// The defination is greped from state-circuit
-#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumIter, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, EnumIter, Hash, Serialize, Deserialize,
+)]
 pub enum MPTProofType {
     /// nonce
     NonceChanged,


### PR DESCRIPTION
Add derive `Ord` to build successfully.