### PR TITLE
[ZK 2-23] add check that final mpt update row is padding

### DIFF
--- a/src/gadgets/is_zero.rs
+++ b/src/gadgets/is_zero.rs
@@ -57,7 +57,8 @@ impl IsZeroGadget {
         );
         cb.assert_zero(
             "inverse_or_zero is 0 or inverse_or_zero is inverse of value",
-            inverse_or_zero.current() * (Query::one() - value.current() * inverse_or_zero.current()),
+            inverse_or_zero.current()
+                * (Query::one() - value.current() * inverse_or_zero.current()),
         );
         Self {
             value,

--- a/src/mpt.rs
+++ b/src/mpt.rs
@@ -156,8 +156,9 @@ impl MptCircuitConfig {
                 let n_assigned_rows = self.mpt_update.assign(&mut region, proofs, randomness);
 
                 assert!(
-                    n_assigned_rows <= n_rows,
-                    "mpt circuit requires {n_assigned_rows} rows > limit of {n_rows} rows"
+                    2 + n_assigned_rows <= n_rows,
+                    "mpt circuit requires {n_assigned_rows} rows for mpt updates + 1 initial \
+                    all-zero row + at least 1 final padding row. Only {n_rows} rows available."
                 );
 
                 for offset in 1 + n_assigned_rows..n_rows {


### PR DESCRIPTION
This ensures that every starting row of an mpt update (which is what gets looked up by the rw circuit) has a matching ending row. This ensures that every mpt update is fully checked by the circuit.

Previously, the circuit would verify even if the final mpt update was incomplete. Having a padding row at the end prevents this from happening, because the padding row corresponds to a complete 1-row proof that the account with address 0 doesn't exist in an mpt that is empty.