### PR TITLE
Require that row is enabled for non-poseidon lookups

### DIFF
--- a/src/constraint_builder.rs
+++ b/src/constraint_builder.rs
@@ -83,27 +83,6 @@ impl<F: FieldExt> ConstraintBuilder<F> {
         self.lookups.push((name, lookup))
     }
 
-    pub fn add_lookup_with_default<const N: usize>(
-        &mut self,
-        name: &'static str,
-        left: [Query<F>; N],
-        right: [Query<F>; N],
-        default: [Query<F>; N],
-    ) {
-        let condition = self
-            .conditions
-            .iter()
-            .skip(1) // Save a degree by skipping every row selector
-            .fold(BinaryQuery::one(), |a, b| a.and(b.clone()));
-        let lookup = left
-            .into_iter()
-            .zip(default.into_iter())
-            .map(|(a, b)| condition.select(a, b))
-            .zip(right.into_iter())
-            .collect();
-        self.lookups.push((name, lookup))
-    }
-
     pub fn build_columns<const A: usize, const B: usize, const C: usize>(
         &self,
         cs: &mut ConstraintSystem<F>,

--- a/src/gadgets/byte_representation.rs
+++ b/src/gadgets/byte_representation.rs
@@ -219,7 +219,7 @@ mod test {
             layouter.assign_region(
                 || "",
                 |mut region| {
-                    for offset in 0..1024 {
+                    for offset in 0..(8 * 256) {
                         selector.enable(&mut region, offset);
                     }
                     byte_bit.assign(&mut region);

--- a/src/gadgets/canonical_representation.rs
+++ b/src/gadgets/canonical_representation.rs
@@ -250,7 +250,7 @@ mod test {
             layouter.assign_region(
                 || "",
                 |mut region| {
-                    for offset in 0..256 {
+                    for offset in 0..(8 * 256) {
                         selector.enable(&mut region, offset);
                     }
                     byte_bit.assign(&mut region);

--- a/src/gadgets/key_bit.rs
+++ b/src/gadgets/key_bit.rs
@@ -191,7 +191,7 @@ mod test {
             layouter.assign_region(
                 || "",
                 |mut region| {
-                    for offset in 0..32 {
+                    for offset in 0..(8 * 256) {
                         selector.enable(&mut region, offset);
                     }
 

--- a/src/gadgets/poseidon.rs
+++ b/src/gadgets/poseidon.rs
@@ -1,10 +1,9 @@
-use crate::constraint_builder::{AdviceColumn, ConstraintBuilder, FixedColumn, Query};
-use halo2_proofs::{
-    arithmetic::FieldExt,
-    plonk::{Advice, Column, Fixed},
-};
+use crate::constraint_builder::{AdviceColumn, FixedColumn};
+use halo2_proofs::plonk::{Advice, Column, Fixed};
 #[cfg(test)]
-use halo2_proofs::{circuit::Region, halo2curves::bn256::Fr, plonk::ConstraintSystem};
+use halo2_proofs::{
+    arithmetic::FieldExt, circuit::Region, halo2curves::bn256::Fr, plonk::ConstraintSystem,
+};
 #[cfg(test)]
 use hash_circuit::hash::Hashable;
 
@@ -17,42 +16,6 @@ pub trait PoseidonLookup {
     fn lookup_columns_generic(&self) -> (Column<Fixed>, [Column<Advice>; 6]) {
         let (fixed, adv) = self.lookup_columns();
         (fixed.0, adv.map(|col| col.0))
-    }
-}
-
-impl<F: FieldExt> ConstraintBuilder<F> {
-    pub fn poseidon_lookup(
-        &mut self,
-        name: &'static str,
-        [left, right, domain, hash]: [Query<F>; 4],
-        poseidon: &impl PoseidonLookup,
-    ) {
-        let extended_queries = [
-            Query::one(),
-            hash,
-            left,
-            right,
-            Query::zero(),
-            domain,
-            Query::one(),
-        ];
-
-        let (q_enable, [hash, left, right, control, domain_spec, head_mark]) =
-            poseidon.lookup_columns();
-
-        self.add_lookup(
-            name,
-            extended_queries,
-            [
-                q_enable.current(),
-                hash.current(),
-                left.current(),
-                right.current(),
-                control.current(),
-                domain_spec.current(),
-                head_mark.current(),
-            ],
-        )
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ use halo2_proofs::{
 };
 use mpt_zktrie::state::{builder::HASH_SCHEME_DONE, witness::WitnessGenerator, ZktrieState};
 
-const N_ROWS: usize = 1024;
+const N_ROWS: usize = 8 * 256 + 1;
 const STORAGE_ADDRESS: Address = Address::repeat_byte(1);
 
 fn initial_generator() -> WitnessGenerator {


### PR DESCRIPTION
Previously, it was possible to satisfy lookups using rows that weren't enabled, meaning that most constraints were not being applied.

This fixes that for non-poseidon lookups.

This problem doesn't apply to poseidon lookups because the `q_enable` selector column of the poseidon table is part of the poseidon lookup and we check that it is 1.