### PR TITLE
Why does all_padding test produce a synthesis error?

### DIFF
--- a/src/gadgets/mpt_update.rs
+++ b/src/gadgets/mpt_update.rs
@@ -381,7 +381,7 @@ impl MptUpdateConfig {
                         self.assign_proof(&mut region, 0, &proof, randomness);
                     } else if i == 0 {
                         // Need make one assignment so region size is calculated correctly.
-                        self.key.assign(&mut region, 0, 0);
+                        self.new_hash.assign(&mut region, 0, 0);
                     } else {
                         self.assign_padding_row(&mut region, 0);
                     }

--- a/src/gadgets/mpt_update/assign.rs
+++ b/src/gadgets/mpt_update/assign.rs
@@ -264,6 +264,7 @@ impl MptUpdateConfig {
         self.key.assign(region, offset, *ZERO_PAIR_HASH);
         self.other_key.assign(region, offset, *ZERO_PAIR_HASH);
         self.domain.assign(region, offset, HashDomain::Pair);
+        self.new_hash.assign(region, offset, 0);
     }
 
     fn assign_storage_trie_rows(


### PR DESCRIPTION
when there are no mpt updates, if the padding row assigments (assignments where global offset > 0) and 0 row assignments (assignments where global offset == 0) don't have an overlapping column, i think that the halo2 parallel layouter causes the regions to overlap, which produces a synthesis error? Is this working as intened?
