### PR TITLE
Corrected typos

### DIFF
--- a/spec/mpt-proof.md
+++ b/spec/mpt-proof.md
@@ -201,19 +201,19 @@ Notice that the zkTrie adds only one bit of common prefix at each level of its d
 
 #### PathType::Common
 
-`PathType::Common` refers to the sitation that the old and new path share the same toplogical configuration.
+`PathType::Common` refers to the situation that the old and new path share the same topological, top logical configuration.
 
 This can correspond to the toloplgical configuration change on the whole path in the modify operation, or the common path (not extended one) of the insert to/delete from append, or the insert to/delete from fill operations. 
 
 #### PathType::ExtensionNew
 
-`PathType::ExtensionNew` refers to the sitation that the new path extends the old path in its toplogical configuration.
+`PathType::ExtensionNew` refers to the situation that the new path extends the old path in its topological, top logical configuration.
 
 This can correspond to the extended part of the path in insert to append, insert to fill operations.
 
 #### PathType::ExtensionOld
 
-`PathType::ExtensionOld` refers to the sitation that the old path extends the new path in its toplogical configuration.
+`PathType::ExtensionOld` refers to the situation that the old path extends the new path in its topological, top logical configuration.
 
 This can correspond to the extended part of the path in delete from append, delete from fill operations.
 


### PR DESCRIPTION
### Changes

1. **File:** `/spec/mpt-proof.md`
    - Fixed `sitation` to `situation` (Line 210)
    - Fixed `toplogical` to `topological, top logical` (Line 216)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.